### PR TITLE
Ignore run_exports for `python`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,6 @@ source:
     - requirements-no-lalsuite.patch
 
 build:
-  error_overdepending: true
-  error_overlinking: true
-  number: 0
-  skip: true  # [win or py<36]
-  script: {{ PYTHON }} -m pip install . -vv --install-option=--use-system-libraries
   entry_points:
     - bayestar-localize-coincs = ligo.skymap.tool.bayestar_localize_coincs:main
     - bayestar-localize-lvalert = ligo.skymap.tool.bayestar_localize_lvalert:main
@@ -40,6 +35,13 @@ build:
     - ligo-skymap-plot-stats = ligo.skymap.tool.ligo_skymap_plot_stats:main
     - ligo-skymap-plot-volume = ligo.skymap.tool.ligo_skymap_plot_volume:main
     - ligo-skymap-stats = ligo.skymap.tool.ligo_skymap_stats:main
+  error_overdepending: true
+  error_overlinking: true
+  ignore_run_exports:
+    - python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --install-option=--use-system-libraries
+  skip: true  # [win or py<36]
 
 requirements:
   build:
@@ -136,7 +138,6 @@ test:
     - ligo.skymap.util.numpy
     - ligo.skymap.util.sqlite
   requires:
-    #- astroquery
     - lalapps
     - pytest
   commands:


### PR DESCRIPTION
This PR adds `ignore_run_exports: [python]`; the `run_exports` for python-3.8.2 currently breaks the build, so we just ignore it here. Maybe this will break something else later, but that's for a future me to figure out.

The build number has not been bumped because the original build of this version failed as a result of this issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
