### PR TITLE
Pin numpy build to minimum requirement

### DIFF
--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -14,6 +14,8 @@ gsl:
 - '2.6'
 libcblas:
 - 3.8 *netlib
+numpy:
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -25,3 +27,5 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
+- - python
+  - numpy

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ gsl:
 - '2.6'
 libcblas:
 - 3.8 *netlib
+numpy:
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -25,3 +27,5 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
+- - python
+  - numpy

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ gsl:
 - '2.6'
 libcblas:
 - 3.8 *netlib
+numpy:
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -25,3 +27,5 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
+- - python
+  - numpy

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -14,6 +14,8 @@ libcblas:
 - 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -22,3 +24,6 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ libcblas:
 - 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -22,3 +24,6 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ libcblas:
 - 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -22,3 +24,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - python
+  - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ build:
   error_overlinking: true
   ignore_run_exports:
     - python
-  number: 1
+  number: 2
   script:
     - CFLAGS="${CFLAGS} -O3 -flto" CPPFLAGS="${CPPFLAGS} -O3" LIGO_SKYMAP_USE_SYSTEM_CHEALPIX=1 {{ PYTHON }} -m pip install . -vv
   skip: true  # [win or py<37]
@@ -56,7 +56,7 @@ requirements:
     - libcblas
     - libgomp  # [linux and not aarch64]
     - llvm-openmp  # [osx]
-    - numpy >=1.19.3
+    - numpy 1.19
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ requirements:
     - libcblas
     - libgomp  # [linux and not aarch64]
     - llvm-openmp  # [osx]
-    - numpy 1.19.4
+    - numpy 1.19.4  # [py<39]
+    - numpy  # [py>=39]
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - libcblas
     - libgomp  # [linux and not aarch64]
     - llvm-openmp  # [osx]
-    - numpy 1.19.3
+    - numpy 1.19.4
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - libcblas
     - libgomp  # [linux and not aarch64]
     - llvm-openmp  # [osx]
-    - numpy 1.19
+    - numpy 1.19.3
     - pip
     - python
     - setuptools


### PR DESCRIPTION
This PR pins the `numpy` entry in `requirements/host` to the minimum requirement (as opposed to `>=min`) so that the build runs against exactly that version and the resulting package has `numpy >=min,<2.0a0` in the requirements.

This is just to broaden the compatibility of this package with others.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
